### PR TITLE
Use highlight class instead of inline styles

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,4 +1,5 @@
 var remove    = require('remove-element')
+var css       = require('insert-css')
 var Emitter   = require('events/')
 var xtend     = require('xtend')
 var vkey      = require('vkey')
@@ -6,7 +7,7 @@ var fs        = require('fs')
 
 module.exports = createMenu
 
-require('insert-css')(
+css(
   fs.readFileSync(__dirname + '/style.css', 'utf8')
 )
 
@@ -44,8 +45,19 @@ function createMenu(opts) {
 
   // styles
   list.classList.add('browser-terminal-menu')
-  list.style.color = opts.fg
-  list.style.backgroundColor = opts.bg
+  css(
+    '.browser-terminal-menu {\n' +
+    '  background-color: ' + opts.bg + ';\n' +
+    '}\n' +
+    '.browser-terminal-menu li {\n' +
+    '  color: ' + opts.fg + ';\n' +
+    '}\n' +
+    '.browser-terminal-menu li.highlighted {\n' +
+    '  color: ' + opts.bg + ';\n' +
+    '  background-color: ' + opts.fg + ';\n' +
+    '}'
+  )
+
 
   if ('x' in opts) list.style.left = opts.x + 'em'
   if ('y' in opts) list.style.top  = opts.y + 'em'
@@ -113,13 +125,11 @@ function createMenu(opts) {
   }
 
   function enable(item) {
-    item.style.backgroundColor = opts.fg
-    item.style.color = opts.bg
+    item.classList.add('highlighted')
   }
 
   function disable(item) {
-    item.style.color = opts.fg
-    item.style.backgroundColor = opts.bg
+    item.classList.remove('highlighted')
   }
 
   function next() {


### PR DESCRIPTION
This allows easier overriding of built-in style constraints.

e.g., let's say I want the background color of the menu to differ from the highlight color, I could override the normal behavior like so:

``` css
body {
  background: #363d43;
}
.browser-terminal-menu {
  background: transparent;
}
.browser-terminal-menu li {
  color: #fff;
}
.browser-terminal-menu li.highlighted {
  color: #fff;
  background-color: #527cff;
}
```

which yields:
![screen shot 2014-08-05 at 4 56 25 pm](https://cloud.githubusercontent.com/assets/103672/3820666/26e4ac4e-1cfc-11e4-9521-8cf8b908c05f.png)
