### PR TITLE
suppress 'EventEmitter memory leak detected' warning

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -29,6 +29,8 @@ function createMenu(opts) {
   var list = document.createElement('ul')
   var menu = new Emitter
 
+  menu.setMaxListeners(Infinity)
+
   var latestLineText = ''
   var latestLine = null
   var items = []


### PR DESCRIPTION
This happens if you have more than 10 menu items.
